### PR TITLE
Fix: TOPIC 명령어 파라미터 검증 오류 수정 (#1)

### DIFF
--- a/CommandHandler.cpp
+++ b/CommandHandler.cpp
@@ -127,7 +127,8 @@ void CommandHandler::handleJoin(Client& client, const Message& msg)
 	}
 
 	// 파라미터 확인
-	if (msg.getParams().empty()) {
+	// join :로 들어온 경우 빈 문자열로 파싱되므로 에러 조건 추가
+	if (msg.getParams().empty() || msg.getParams()[0].empty()) {
 		client.send_reply(ERR_NEEDMOREPARAMS, "JOIN :Not enough parameters");
 		return ;
 	}
@@ -137,7 +138,7 @@ void CommandHandler::handleJoin(Client& client, const Message& msg)
 		key = msg.getParams()[1];
 	}
 	// 채널 이름 검증 (# 또는 &로 시작)
-	if (channel_name.empty() || (channel_name[0] != '#' && channel_name[0] != '&')) {
+	if (channel_name[0] != '#' && channel_name[0] != '&') {
 		client.send_reply(ERR_NOSUCHCHANNEL, channel_name + " :No such channel");
 		return ;
 	}
@@ -339,7 +340,7 @@ void	CommandHandler::handleTopic(Client& client, const Message& msg)
 		return;
 	}
 
-	if (msg.getParams().empty()) {
+	if (msg.getParams().empty() || msg.getParams()[0].empty()) {
 		client.send_reply(ERR_NEEDMOREPARAMS, "TOPIC :Not enough parameters");
 		return ;
 	}
@@ -397,7 +398,7 @@ void	CommandHandler::handleInvite(Client& client, const Message& msg)
 	}
 
 	if (msg.getParams().size() < 2) {
-		client.send_reply(ERR_NEEDMOREPARAMS, "TOPIC :Not enough parameters");
+		client.send_reply(ERR_NEEDMOREPARAMS, "INVITE :Not enough parameters");
 		return ;
 	}
 	std::string target_nick = msg.getParams()[0];
@@ -465,7 +466,7 @@ void	CommandHandler::handleMode(Client& client, const Message& msg)
 		return;
 	}
 	if (msg.getParams().size() < 2) {
-		client.send_reply(ERR_NEEDMOREPARAMS, "TOPIC :Not enough parameters");
+		client.send_reply(ERR_NEEDMOREPARAMS, "MODE :Not enough parameters");
 		return ;
 	}
 

--- a/CommandHandler.cpp
+++ b/CommandHandler.cpp
@@ -343,8 +343,8 @@ void	CommandHandler::handleTopic(Client& client, const Message& msg)
 		client.send_reply(ERR_NEEDMOREPARAMS, "TOPIC :Not enough parameters");
 		return ;
 	}
-	//
-	std::string channel_name = msg.getParams()[1];
+
+	std::string channel_name = msg.getParams()[0];
 
 	Channel* ch = server.getChannel(channel_name);
 	if (!ch) {
@@ -376,7 +376,7 @@ void	CommandHandler::handleTopic(Client& client, const Message& msg)
 		}
 	}
 	ch->setTopic(change_topic);
-	std::string topic_msg = ":" + client.getNickname() + "!" + client.getUsername() + "@localhost TOPIC " + channel_name + ":" + change_topic + "\r\n";
+	std::string topic_msg = ":" + client.getNickname() + "!" + client.getUsername() + "@localhost TOPIC " + channel_name + " :" + change_topic + "\r\n";
 
 	server.sendToClient(client.getFd(), topic_msg);
 	server.broadcastToChannel(channel_name, topic_msg, client.getFd());


### PR DESCRIPTION
🐛 문제
Segmentation Fault: TOPIC 명령어에서 잘못된 인덱스 접근(msg.getParams()[1])으로 인한 서버 비정상 종료 발생.

Protocol Violation: JOIN :과 같이 빈 파라미터 입력 시 에러 메시지 형식이 깨지는 문제.

Typo: INVITE, MODE 에러 응답 시 명령어 이름이 TOPIC으로 잘못 출력되는 문제.

🛠 수정 내용
안정성 강화: JOIN, TOPIC 명령어에 빈 파라미터(msg.getParams()[0].empty()) 체크 가드 로직 추가.

인덱스 교정: TOPIC 명령어의 채널명 참조 인덱스를 1에서 0으로 수정.

에러 처리 통일: JOIN : 처리 시 다른 커맨드와 동일하게 461 ERR_NEEDMOREPARAMS로 응답하도록 변경.

오타 수정: INVITE, MODE 명령어 내 잘못된 에러 메시지 문구 수정.

🧪 테스트 결과
JOIN : → 461 JOIN :Not enough parameters 응답 확인 (Irssi 에러 해결)

TOPIC → 461 TOPIC :Not enough parameters (서버 종료 없이 정상 응답)

TOPIC #room → 현재 토픽 정상 조회

TOPIC #room :hello → 토픽 정상 변경 및 브로드캐스트 확인

Closes #1