### PR TITLE
feat: JOIN 성공 시 TOPIC 상태 응답 (331, 332) 추가

### DIFF
--- a/CommandHandler.cpp
+++ b/CommandHandler.cpp
@@ -184,6 +184,11 @@ void CommandHandler::handleJoin(Client& client, const Message& msg)
         }
     }
 
+	if (ch->getChannelTopic().empty()) {
+		client.send_reply(RPL_NOTOPIC, client.getNickname() + " " + channel_name + " No topic is set");
+	} else {
+		client.send_reply(RPL_TOPIC, client.getNickname() + " " + channel_name + ch->getChannelTopic());
+	}
 	client.send_reply(RPL_NAMREPLY, client.getNickname() + " = " + channel_name + " :" + name_list);
 	client.send_reply(RPL_ENDOFNAMES, client.getNickname() + " " + channel_name + " :End of /NAMES list");
 }


### PR DESCRIPTION
- 채널 입장 성공 직후 클라이언트에게 현재 체널의 Topic 상태 알림 로직 추가
- 주제 없는 경우: RPL_NOTOPIC (331)
- 주제 있는 경우: RPL_TOPIC (332)

Ref: RFC 1459 Section 4.2.1 (Join message)